### PR TITLE
add environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,8 @@ MyST-syntax markdown, then build the book by following the instructions in the
 
 ### Creating an environment
 
-1. Clone the following repositories: [cli](https://github.com/ExecutableBookProject/cli), [MyST-NB](https://github.com/ExecutableBookProject/MyST-NB), [sphinx-book-theme](https://github.com/ExecutableBookProject/sphinx-book-theme)
-2. `conda create -n venv_name pip matplotlib numpy scipy sympy pandas networkx`
-3. Activate conda environment
-4. Find anaconda directory and fin the venv folder. It could look something like this: `/anaconda3/envs/venv_name/`
-5. For each of the cloned repositories run the following: `/anaconda3/envs/venv_name/bin/pip install -e.`
+1. `conda env create -f environment.yml`
+2.  `conda activte edp`
 
 ### Building a Jupyter Book
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,25 @@
+name: ebp
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7.*
+  - jupyter
+  - sphinx=2.4.4
+  - pydata-sphinx-theme
+  - ghp-import
+  - matplotlib
+  - numpy
+  - scipy
+  - sympy
+  - pandas
+  - networkx
+  - numba
+  - pip
+  - pip:
+    - git+https://github.com/ExecutableBookProject/MyST-NB.git
+    - jupyter-cache[cli]
+    - git+https://github.com/mwouts/jupytext.git
+    - git+https://github.com/ExecutableBookProject/cli
+    - git+https://github.com/ExecutableBookProject/sphinx-book-theme
+    


### PR DESCRIPTION
Just built the book -- worked well except that numba was missing from the package list in the Readme.  Perhaps bundle an [environment.yml](https://github.com/eoas-ubc/quantecon-example/blob/condaenv/environment.yml) to make it a singile step install?
