### PR TITLE
Add gh workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-example
+
+      - name: Install jupyter_book
+        shell: bash -l {0}
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
+
+      - name: Build QuantEcon Example
+        shell: bash -l {0}
+        run: jb build book/
+
+      - name: Install SSH Client 🔑
+        uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          SSH: true
+          BRANCH: gh-pages
+          FOLDER: book/_build/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           miniconda-version: 'latest'
           python-version: 3.7
           environment-file: environment.yml
-          activate-environment: ebp
+          activate-environment: qe-example
 
       - name: Install jupyter_book
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Test Build
+on:
+  push:
+    branches-ignore:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: ebp
+
+      - name: Install jupyter_book
+        shell: bash -l {0}
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
+
+      - name: Build QuantEcon Example
+        shell: bash -l {0}
+        run: jb build book/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy (Nightly)
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-example
+
+      - name: Install jupyter_book
+        shell: bash -l {0}
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
+
+      - name: Build QuantEcon Example
+        shell: bash -l {0}
+        run: jb build book/
+
+      - name: Install SSH Client 🔑
+        uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          SSH: true
+          BRANCH: gh-pages
+          FOLDER: book/_build/html

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: ebp
+name: qe-example
 channels:
   - conda-forge
   - defaults
@@ -17,9 +17,5 @@ dependencies:
   - numba
   - pip
   - pip:
-    - git+https://github.com/ExecutableBookProject/MyST-NB.git
-    - jupyter-cache[cli]
-    - git+https://github.com/mwouts/jupytext.git
     - git+https://github.com/ExecutableBookProject/jupyter-book
-    - git+https://github.com/ExecutableBookProject/sphinx-book-theme
 


### PR DESCRIPTION
This PR adds Github workflows for `quantecon-example`. Three files have been added:
- build-and-deploy.yml
- build.yml
- nightly.yml

The following changes have been addressed:
1. The environment name has been updated to reflect the repository's environment as `qe-example`. 
2. Jupyter Book url has been updated from `cli` to `jupyter-book` as `cli` has been depreciated.
3. The build path has been updated to reflect the appropriate book directory name

Something to consider might be to remove `pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master` since this is installed through the environment in case the user wants to run the build locally.

@mmcky would appreciate your feedback!