### PR TITLE
demo of windows encoding problem

### DIFF
--- a/build_book.ps1
+++ b/build_book.ps1
@@ -1,0 +1,3 @@
+#
+$env:PYTHONUTF8=1
+jb build book

--- a/error_log.txt
+++ b/error_log.txt
@@ -1,0 +1,41 @@
+.\build_book.ps1
+Running Sphinx v2.4.4
+building [mo]: targets for 0 po files that are out of date
+building [html]: targets for 18 source files that are out of date
+updating environment: Executing: C:\Users\Phil\repos\quantecon-example\book\docs\pandas.md
+[new config] 18 added, 18 changed, 0 removed
+checking for C:\Users\Phil\repos\quantecon-example\book\docs\quant-econ.bib in bibtex cache... not found
+parsing bibtex file C:\Users\Phil\repos\quantecon-example\book\docs\quant-econ.bib... parsed 1 entries
+reading sources... [100%] docs/writing_good_code
+WARNING: Execution Failed: C:\Users\Phil\repos\quantecon-example\book\docs\pandas.md
+WARNING: Couldn't find cache key for notebook file book\docs\pandas.md. Outputs will not be inserted.
+  Last execution failed with traceback saved in C:\Users\Phil\repos\quantecon-example\book\_build\html/reports/pandas.log
+
+Sphinx error:
+master file C:\Users\Phil\repos\quantecon-example\book\docs\index.md not found
+Traceback (most recent call last):
+  File "c:\users\phil\miniwin\envs\ebp\lib\runpy.py", line 193, in _run_module_as_main
+    "__main__", mod_spec)
+  File "c:\users\phil\miniwin\envs\ebp\lib\runpy.py", line 85, in _run_code
+    exec(code, run_globals)
+  File "C:\Users\phil\miniwin\envs\ebp\Scripts\jb.exe\__main__.py", line 7, in <module>
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\click\core.py", line 829, in __call__
+    return self.main(*args, **kwargs)
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\click\core.py", line 782, in main
+    rv = self.invoke(ctx)
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\click\core.py", line 1259, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\click\core.py", line 1066, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\click\core.py", line 610, in invoke
+    return callback(*args, **kwargs)
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\jupyter_book\commands\__init__.py", line 126, in build
+    "There was an error in building your book. "
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\jupyter_book\utils.py", line 65, in _error
+    raise kind(box)
+ValueError:
+===============================================================================
+
+There was an error in building your book. Look above for the error message.
+
+===============================================================================

--- a/pandas_log.txt
+++ b/pandas_log.txt
@@ -1,0 +1,25 @@
+Traceback (most recent call last):
+  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\jupyter_cache\executors\basic.py", line 157, in execute
+      executenb(nb_bundle.nb, cwd=tmpdirname)
+        File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\nbconvert\preprocessors\execute.py", line 737, in executenb
+	    return ep.preprocess(nb, resources, km=km)[0]
+	      File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\nbconvert\preprocessors\execute.py", line 405, in preprocess
+	          nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
+		    File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\nbconvert\preprocessors\base.py", line 69, in preprocess
+		        nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
+			  File "c:\users\phil\miniwin\envs\ebp\lib\site-packages\nbconvert\preprocessors\execute.py", line 448, in preprocess_cell
+			      raise CellExecutionError.from_cell_and_msg(cell, out)
+			      nbconvert.preprocessors.execute.CellExecutionError: An error occurred while executing the following cell:
+			      ------------------
+			      indices_data = read_data(
+			              indices_list,
+				              start=dt.datetime(1928, 1, 2),
+					              end=dt.datetime(2020, 12, 31)
+						      )
+						      ------------------
+
+^[[1;31m---------------------------------------------------------------------------^[[0m
+^[[1;31mOverflowError^[[0m                             Traceback (most recent call last)
+^[[1;32m<ipython-input-43-e1341c1459ea>^[[0m in ^[[0;36m<module>^[[1;34m^[[0m
+^[[0;32m      2^[[0m         ^[[0mindices_list^[[0m^[[1;33m,^[[0m^[[1;33m^[[0m^[[1;33m^[[0m^[[0m
+^[[0;32m      3^[[0m         ^[[0mstart^[[0m^[[1;33m=^[[0m^[[0mdt^[[0m^[[1;33m.^[[0m^[[0mdatetime^[[0m^[[


### PR DESCRIPTION
Trying to nail down [this issue](https://github.com/executablebooks/jupyter-book/issues/549#issuecomment-624956130).   This shows what happens when I run [process_files.py](https://github.com/phaustin/quantecon-example/blob/encodings/book/docs/process_files.py) on the markdown files to 

1. replace the θ character with "theta"
2. try to remove any mojibaked text using errors="replace"
after these two steps there's still something that windows is unhappy about and it prints [this error message](https://github.com/phaustin/quantecon-example/blob/encodings/error_log.txt).

The default jb example builds fine -- so I'm not sure what the issue is with this content.  
