### PR TITLE
DOC: Fix name of conda env in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MyST-syntax markdown, then build the book by following the instructions in the
 
 
 1. `conda env create -f environment.yml`
-2.  `conda activate edp`
+2. `conda activate qe-example`
 
 
 ### Building a Jupyter Book


### PR DESCRIPTION
Thanks for providing this example - it seems like a very nice demonstration of the capabilities of the `executablebooks` project!

This is just something I caught when getting started working through the example: the name of the environment in the README doesn't match the one in the `environment.yml`. This PR changes the one in the README, but you could just as easily change the README depending on which environment name you want to keep.

Thanks again for putting this together!